### PR TITLE
Fix some failing tests

### DIFF
--- a/graphle/graphle.hpp
+++ b/graphle/graphle.hpp
@@ -39,3 +39,4 @@
 #include <views/duplicate_transposed_edges.hpp>
 #include <views/edge_from_vertex.hpp>
 #include <views/edge_perspective.hpp>
+#include <views/maybe_exists.hpp>

--- a/graphle/meta/value.hpp
+++ b/graphle/meta/value.hpp
@@ -31,6 +31,11 @@ namespace graphle::meta {
     /** @copydoc deduce_as_t */
     template <typename T> constexpr inline deduce_as_t<T> deduce_as = {};
 
+    /** Equivalent to deduce_as_t but always deduces as an lvalue. */
+    template <typename T> using deduce_as_lvalue_t = deduce_as_t<std::remove_reference_t<T>>;
+    /** @copydoc deduce_as_lvalue_t */
+    template <typename T> constexpr inline deduce_as_lvalue_t<T> deduce_as_lvalue = {};
+
 
     /** Checks if a type is meta::none */
     template <typename T> struct is_none : std::bool_constant<std::is_same_v<T, none>> { };

--- a/graphle/utility/functional.hpp
+++ b/graphle/utility/functional.hpp
@@ -70,7 +70,7 @@ namespace graphle::util {
      * @ingroup Utils
      * A function object that makes its argument const.
      */
-    GRAPHLE_MAKE_NIEBLOID_IMPL(as_const, std::as_const);
+    GRAPHLE_MAKE_NIEBLOID_IMPL(as_const, [](auto&& obj) -> decltype(auto) { return std::as_const(obj); });
 
     /**
      * @ingroup Utils

--- a/graphle/utility/vertex_utils.hpp
+++ b/graphle/utility/vertex_utils.hpp
@@ -9,8 +9,8 @@ namespace graphle::util {
      * Finds the first vertex matching the given predicate, or nullptr if no such vertex exists.
      *
      * @param graph The graph to search
-     * @param pred A function object invocable as pred(vertex_of<G>) -> bool.
-     * @return Either a vertex matching the given predicate or nullptr.
+     * @param pred A function object invocable as pred(vertex_of<G>) -> bool
+     * @return Either a vertex matching the given predicate or nullptr
      *
      * @graph_requires{vertex_list_graph<G>}
      */

--- a/graphle/views.hpp
+++ b/graphle/views.hpp
@@ -7,3 +7,4 @@
 #include <views/duplicate_transposed_edges.hpp>
 #include <views/edge_from_vertex.hpp>
 #include <views/edge_perspective.hpp>
+#include <views/maybe_exists.hpp>

--- a/graphle/views/duplicate_transposed_edges.hpp
+++ b/graphle/views/duplicate_transposed_edges.hpp
@@ -8,7 +8,7 @@
 namespace graphle {
     namespace detail {
         template <rng::input_range R> requires (rng::view<R> && is_edge<rng::range_value_t<R>>)
-        class edge_duplication_view : public graphle_view_base, public rng::view_interface<edge_duplication_view<R>> {
+        class edge_duplication_view : public rng::view_interface<edge_duplication_view<R>> {
         public:
             using edge_type = rng::range_value_t<R>;
 

--- a/graphle/views/edge_from_vertex.hpp
+++ b/graphle/views/edge_from_vertex.hpp
@@ -10,7 +10,7 @@
 namespace graphle {
     namespace detail {
         template <rng::input_range R, typename ProjectBound, typename ProjectRange> requires (rng::view<R> && is_vertex<rng::range_value_t<R>>)
-        class edge_from_vertex_view : public graphle_view_base, public rng::view_interface<edge_from_vertex_view<R, ProjectBound, ProjectRange>> {
+        class edge_from_vertex_view : public rng::view_interface<edge_from_vertex_view<R, ProjectBound, ProjectRange>> {
         public:
             using vertex_type = typename rng::range_value_t<R>;
             using edge_type   = std::pair<vertex_type, vertex_type>;

--- a/graphle/views/edge_perspective.hpp
+++ b/graphle/views/edge_perspective.hpp
@@ -11,7 +11,7 @@
 namespace graphle {
     namespace detail {
         template <rng::input_range R, typename Projection> requires (rng::view<R> && is_edge<rng::range_value_t<R>>)
-        class vertex_perspective_view : public graphle_view_base, public rng::view_interface<vertex_perspective_view<R, Projection>> {
+        class vertex_perspective_view : public rng::view_interface<vertex_perspective_view<R, Projection>> {
         public:
             using vertex_type = typename rng::range_value_t<R>::first_type;
             using edge_type   = std::pair<vertex_type, vertex_type>;

--- a/graphle/views/maybe_exists.hpp
+++ b/graphle/views/maybe_exists.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <common.hpp>
+#include <meta/value.hpp>
+#include <utility/range_utils.hpp>
+
+#include <utility>
+#include <optional>
+
+
+namespace graphle {
+    namespace detail {
+        template <rng::input_range R> requires rng::view<R>
+        class maybe_exists_view : public rng::view_interface<maybe_exists_view<R>> {
+        public:
+            constexpr explicit maybe_exists_view(R base_range) : base_range(base_range) {}
+            constexpr explicit maybe_exists_view(meta::deduce_as_t<R>) : base_range(std::nullopt) {}
+
+            [[nodiscard]] constexpr auto begin(void) const { return base_range ? iterator { rng::begin(*base_range) } : iterator { }; }
+            [[nodiscard]] constexpr auto end  (void) const { return base_range ? iterator { rng::end(*base_range) }   : iterator { }; }
+
+            [[nodiscard]] constexpr auto size(void) const requires rng::sized_range<const R> {
+                return base_range ? rng::size(*base_range) : 0;
+            }
+        private:
+            std::optional<R> base_range;
+
+
+            class iterator : public wrapping_iterator<iterator, rng::iterator_t<R>, typename range_iterator_traits<R>::reference> {
+            public:
+                using base = wrapping_iterator<iterator, rng::iterator_t<R>, typename range_iterator_traits<R>::reference>;
+
+                constexpr iterator(void) : wrapped(std::nullopt) {}
+                constexpr explicit iterator(rng::iterator_t<R> wrapped) : wrapped(wrapped) {}
+
+                // Implicitly deleted if defaulted for some reason?
+                constexpr bool operator==(const iterator& o) const {
+                    return wrapped == o.wrapped;
+                }
+
+                // Implicitly deleted if defaulted for some reason?
+                constexpr auto operator<=>(const iterator& o) const {
+                    return wrapped <=> o.wrapped;
+                }
+            private:
+                friend class wrapping_iterator<iterator, rng::iterator_t<R>, typename range_iterator_traits<R>::reference>;
+
+                std::optional<rng::iterator_t<R>> wrapped;
+
+                constexpr decltype(auto) get(void) const { return **wrapped; }
+
+                constexpr void next(void) requires base::is_forward { ++(*wrapped); }
+                constexpr void prev(void) requires base::is_bidirectional { --(*wrapped); }
+                constexpr void advance(std::ptrdiff_t delta) requires base::is_random_access { (*wrapped) += delta; }
+            };
+        };
+    }
+
+
+    namespace views {
+        /**
+         * @ingroup Views
+         * View that either wraps a provided view or is an empty view.
+         * This can be used to provide a wrapper around a range that might not exist, e.g.:
+         * ~~~
+         * std::unordered_map<Key, std::vector<T>> my_values;
+         * using view_type = decltype(ranges::all(my_values.at(key)));
+         *
+         * auto values_for_key = my_values.contains(key)
+         *     ? views::maybe_exists(ranges::all(my_values.at(key)))
+         *     : views::maybe_exists(meta::deduce_type<view_type>);
+         * ~~~
+         */
+        constexpr inline auto maybe_exists = detail::primary_range_adaptor<detail::maybe_exists_view> {};
+    }
+}
+
+

--- a/graphle_test/search/breadth_first_search.cpp
+++ b/graphle_test/search/breadth_first_search.cpp
@@ -6,6 +6,15 @@
 using graphle::test::vertex_list;
 
 
+/** Subset of datastructures for which we can easily find the root vertex if its not equal to structure.root. */
+using datastructure_list_find_root = graphle::meta::type_list<
+    graphle::test::ve_list_graph,
+    graphle::test::ve_map_graph,
+    graphle::test::v_list_out_edge_graph,
+    graphle::test::v_list_in_out_edge_graph
+>;
+
+
 /**
  * @test bfs::visit_tree
  * Visits a tree-like graph using BFS and asserts visitor methods are called in the expected order.
@@ -23,18 +32,203 @@ TEST(bfs, visit_tree) {
     };
 
 
-    using supported_datastructures = graphle::meta::type_list<
-        graphle::test::ve_list_graph,
-        graphle::test::ve_map_graph,
-        graphle::test::out_edge_graph,
-        graphle::test::v_list_out_edge_graph,
-        graphle::test::in_out_edge_graph,
-        graphle::test::v_list_in_out_edge_graph
-    >;
-
-
-    graphle::test::test_visit_order<supported_datastructures>(
+    graphle::test::test_visit_order<graphle::test::datastructure_list>(
         tree,
+        0,
+        expected_visit_order,
+        [] (auto&&... args) { graphle::search::breadth_first_search(GRAPHLE_FWD(args)...); }
+    );
+}
+
+
+/**
+ * @test bfs::visit_dag
+ * Visits a dag graph using BFS and asserts visitor methods are called in the expected order.
+ */
+TEST(bfs, visit_dag) {
+    const auto dag = graphle::test::make_dag_graph();
+
+
+    auto expected_visit_order_from_0 = graphle::test::vertex_order {
+        vertex_list { 0 },
+        vertex_list { 2 },
+        vertex_list { 3, 6 },
+        vertex_list { 4, 7 },
+        vertex_list { 5, 8 },
+    };
+
+
+    auto expected_visit_order_from_1 = graphle::test::vertex_order {
+        vertex_list { 1 },
+        vertex_list { 3 },
+        vertex_list { 4 },
+        vertex_list { 5 },
+        vertex_list { 6, 8 },
+        vertex_list { 7 }
+    };
+
+
+    SUBTEST_SCOPE("root_vertex_0") {
+        graphle::test::test_visit_order<graphle::test::datastructure_list>(
+            dag,
+            0,
+            expected_visit_order_from_0,
+            [] (auto&&... args) { graphle::search::breadth_first_search(GRAPHLE_FWD(args)...); }
+        );
+    }
+
+
+    SUBTEST_SCOPE("root_vertex_1") {
+        graphle::test::test_visit_order<datastructure_list_find_root>(
+            dag,
+            1,
+            expected_visit_order_from_1,
+            [] (auto&&... args) { graphle::search::breadth_first_search(GRAPHLE_FWD(args)...); }
+        );
+    }
+}
+
+
+/**
+ * @test bfs::visit_cyclic
+ * Visits a cyclic graph using BFS and asserts visitor methods are called in the expected order.
+ */
+TEST(bfs, visit_cyclic) {
+    const auto cyclic = graphle::test::make_cyclic_graph();
+
+
+    auto expected_visit_order_from_0 = graphle::test::vertex_order {
+        vertex_list { 0 },
+        vertex_list { 2 },
+        vertex_list { 3 },
+        vertex_list { 4 },
+        vertex_list { 5 },
+        vertex_list { 6 },
+        vertex_list { 7 },
+        vertex_list { 8 }
+    };
+
+
+    auto expected_visit_order_from_1 = graphle::test::vertex_order {
+        vertex_list { 1 },
+        vertex_list { 3 },
+        vertex_list { 4 },
+        vertex_list { 5 },
+        vertex_list { 6 },
+        vertex_list { 7, 2 },
+        vertex_list { 8 }
+    };
+
+
+    SUBTEST_SCOPE("root_vertex_0") {
+        graphle::test::test_visit_order<graphle::test::datastructure_list>(
+            cyclic,
+            0,
+            expected_visit_order_from_0,
+            [] (auto&&... args) { graphle::search::breadth_first_search(GRAPHLE_FWD(args)...); }
+        );
+    }
+
+
+    SUBTEST_SCOPE("root_vertex_1") {
+        graphle::test::test_visit_order<datastructure_list_find_root>(
+            cyclic,
+            1,
+            expected_visit_order_from_1,
+            [] (auto&&... args) { graphle::search::breadth_first_search(GRAPHLE_FWD(args)...); }
+        );
+    }
+}
+
+
+/**
+ * @test bfs::visit_linear
+ * Visits a linear graph using BFS and asserts visitor methods are called in the expected order.
+ */
+TEST(bfs, visit_linear) {
+    const auto linear = graphle::test::make_linear_graph();
+
+
+    auto expected_visit_order = graphle::test::vertex_order {
+        vertex_list { 0 },
+        vertex_list { 1 },
+        vertex_list { 2 },
+        vertex_list { 3 },
+        vertex_list { 4 },
+        vertex_list { 5 }
+    };
+
+
+    graphle::test::test_visit_order<graphle::test::datastructure_list>(
+        linear,
+        0,
+        expected_visit_order,
+        [] (auto&&... args) { graphle::search::breadth_first_search(GRAPHLE_FWD(args)...); }
+    );
+}
+
+
+/**
+ * @test bfs::visit_bidirectional_edge
+ * Visits a bidirectional edge graph using BFS and asserts visitor methods are called in the expected order.
+ */
+TEST(bfs, visit_bidirectional_edge) {
+    const auto bidir_edge = graphle::test::make_bidirectional_edge_graph();
+
+
+    auto expected_visit_order_from_0 = graphle::test::vertex_order {
+        vertex_list { 0 },
+        vertex_list { 1 },
+        vertex_list { 2 },
+        vertex_list { 3, 4 },
+        vertex_list { 5 }
+    };
+
+
+    auto expected_visit_order_from_4 = graphle::test::vertex_order {
+        vertex_list { 4 },
+        vertex_list { 2 },
+        vertex_list { 1, 3 },
+        vertex_list { 5 }
+    };
+
+
+    SUBTEST_SCOPE("root_vertex_0") {
+        graphle::test::test_visit_order<graphle::test::datastructure_list>(
+            bidir_edge,
+            0,
+            expected_visit_order_from_0,
+            [] (auto&&... args) { graphle::search::breadth_first_search(GRAPHLE_FWD(args)...); }
+        );
+    }
+
+
+    SUBTEST_SCOPE("root_vertex_4") {
+        graphle::test::test_visit_order<datastructure_list_find_root>(
+            bidir_edge,
+            4,
+            expected_visit_order_from_4,
+            [] (auto&&... args) { graphle::search::breadth_first_search(GRAPHLE_FWD(args)...); }
+        );
+    }
+}
+
+
+/**
+ * @test bfs::visit_size_one
+ * Visits a size-one graph using BFS and asserts visitor methods are called in the expected order.
+ */
+TEST(bfs, visit_size_one) {
+    const auto size_one = graphle::test::make_size_one_graph();
+
+
+    auto expected_visit_order = graphle::test::vertex_order {
+        vertex_list { 0 }
+    };
+
+
+    graphle::test::test_visit_order<graphle::test::datastructure_list>(
+        size_one,
         0,
         expected_visit_order,
         [] (auto&&... args) { graphle::search::breadth_first_search(GRAPHLE_FWD(args)...); }

--- a/graphle_test/search/test_visit_order.hpp
+++ b/graphle_test/search/test_visit_order.hpp
@@ -54,13 +54,18 @@ namespace graphle::test {
             };
 
 
-            auto root_vertex = [&] {
-                if constexpr (requires { structure.root; }) return structure.root.get();
-                else return graphle::util::find_vertex(graph, [&] (const auto* v) { return v->vertex_id == root; });
-            } ();
-
-
             SUBTEST_SCOPE(typeid(DS).name()) {
+                auto root_vertex = [&] {
+                    if constexpr (vertex_list_graph<decltype(graph)>) {
+                        return util::find_vertex(graph, [&] (auto v) { return v->vertex_id == root; });
+                    } else if constexpr (requires { structure.root; }) {
+                        if (structure.root->vertex_id == root) return structure.root.get();
+                    }
+
+                    FAIL("Cannot find root vertex for the given graph type.");
+                } ();
+
+
                 std::invoke(
                     algorithm,
                     graph,


### PR DESCRIPTION
Properly fix the temporary workaround where the map_graph test datastructure previously would use an empty subrange over its first edge list as a dummy empty range if no edges existed for the given key. map_graph now uses the new maybe_exists view. Also fixed some issues w.r.t. reference vs lvalues returned by get() for wrapping_iterator.